### PR TITLE
Fix Poetry install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ $(SYS_PYTHON):
 .PHONY: deps
 deps: $(POETRY) $(POETRY_DEPS)
 $(POETRY): $(SYS_PYTHON)
-	curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | $(SYS_PYTHON) - --no-modify-path
+	curl -sSL https://install.python-poetry.org | $(SYS_PYTHON) -
 $(POETRY_DEPS): $(POETRY) pyproject.toml poetry.lock
 	$(POETRY) install --remove-untracked
 	@touch $@


### PR DESCRIPTION
The get-poetry.py script is deprecated. The original command used to install poetry will now fail with the error:

> Version 1.2.0 is not supported by this installer! Please specify a version prior to 1.2.0a1 to continue!

I've updated the command to avoid this error.