### PR TITLE
Add gcc-p1144-trunk

### DIFF
--- a/compilers.yaml
+++ b/compilers.yaml
@@ -6,13 +6,14 @@ compilers:
     # These are slowly replacing the ones in admin-daily-builds.sh
     - { image: clang, name: llvm, args: llvm-trunk }
     - { image: gcc, name: gcc }
+    - { image: gcc, name: gcc_cobol_master, args: cobol-master }
     - { image: gcc, name: gcc_contracts, args: lock3-contracts-trunk }
     - { image: gcc, name: gcc_contracts_labels, args: lock3-contracts-labels-trunk }
     - { image: gcc, name: gcc_contracts_nonattr, args: contracts-nonattr-trunk }
-    - { image: gcc, name: gcc_modules, args: cxx-modules-trunk }
     - { image: gcc, name: gcc_coroutines, args: cxx-coroutines-trunk }
     - { image: gcc, name: gcc_gccrs_master, args: gccrs-master }
-    - { image: gcc, name: gcc_cobol_master, args: cobol-master }
+    - { image: gcc, name: gcc_modules, args: cxx-modules-trunk }
+    - { image: gcc, name: gcc_p1144, args: p1144-trunk }
     - { image: clang, name: clang }
     - { image: clang, name: clang_amdgpu, args: rocm-trunk }
     - { image: clang, name: clang_assertions, args: assertions-trunk }


### PR DESCRIPTION
See https://github.com/compiler-explorer/infra/issues/1157

Also, sort the gcc builders alphabetically so it's less arbitrary where a new one would be added.