### PR TITLE
Route light builds to small/medium runner fleets

### DIFF
--- a/.github/workflows/build-daily-c2rust.yml
+++ b/.github/workflows/build-daily-c2rust.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-cc65.yml
+++ b/.github/workflows/build-daily-cc65.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-ccc.yml
+++ b/.github/workflows/build-daily-ccc.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-clad-trunk-clang-21.1.0.yml
+++ b/.github/workflows/build-daily-clad-trunk-clang-21.1.0.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-clad.yml
+++ b/.github/workflows/build-daily-clad.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-clspv.yml
+++ b/.github/workflows/build-daily-clspv.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-cppfront.yml
+++ b/.github/workflows/build-daily-cppfront.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-dotnet.yml
+++ b/.github/workflows/build-daily-dotnet.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'medium' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-dxc.yml
+++ b/.github/workflows/build-daily-dxc.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-go.yml
+++ b/.github/workflows/build-daily-go.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-hylo.yml
+++ b/.github/workflows/build-daily-hylo.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-ispc.yml
+++ b/.github/workflows/build-daily-ispc.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-jakt.yml
+++ b/.github/workflows/build-daily-jakt.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-lc3.yml
+++ b/.github/workflows/build-daily-lc3.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-madpascal.yml
+++ b/.github/workflows/build-daily-madpascal.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-micropython.yml
+++ b/.github/workflows/build-daily-micropython.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-miri.yml
+++ b/.github/workflows/build-daily-miri.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'medium' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-movfuscator.yml
+++ b/.github/workflows/build-daily-movfuscator.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-mrustc.yml
+++ b/.github/workflows/build-daily-mrustc.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-ncc-ng.yml
+++ b/.github/workflows/build-daily-ncc-ng.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-pahole.yml
+++ b/.github/workflows/build-daily-pahole.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-tinycc.yml
+++ b/.github/workflows/build-daily-tinycc.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-vast.yml
+++ b/.github/workflows/build-daily-vast.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/.github/workflows/build-daily-wyrm.yml
+++ b/.github/workflows/build-daily-wyrm.yml
@@ -51,7 +51,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0

--- a/compilers.yaml
+++ b/compilers.yaml
@@ -59,25 +59,25 @@ compilers:
     - { image: clang, name: clang_variadic_friends, args: variadic-friends-trunk, repos: ["https://github.com/dancrn/llvm-project/tree/cxx-variadic-friends"] }
     - { image: clang, name: clang_hana, args: hana-clang-trunk, repos: ["https://github.com/hanickadot/llvm-project/tree/compiler-explorer/hana-clang"] }
     - { image: clang, name: clang_swiftlang, args: swiftlang-trunk, repos: ["https://github.com/swiftlang/llvm-project/tree/next"] }
-    - { image: dotnet, name: dotnet, command: build.sh, args: trunk, repos: ["https://github.com/dotnet/runtime"] }
+    - { image: dotnet, name: dotnet, command: build.sh, args: trunk, repos: ["https://github.com/dotnet/runtime"] , size: medium}
     - { image: clang, name: mlir_trunk, args: mlir-trunk }
-    - { image: go, name: go }
-    - { image: ccc, name: ccc, command: build.sh, args: main, repos: ["https://github.com/anthropics/claudes-c-compiler/tree/main"] }
-    - { image: misc, name: tinycc, command: build-tinycc.sh }
-    - { image: misc, name: cc65, command: buildcc65.sh, repos: ["https://github.com/cc65/cc65/tree/master"] }
-    - { image: misc, name: mrustc, command: build-mrustc.sh, args: master, repos: ["https://github.com/thepowersgang/mrustc/tree/master"] }
+    - { image: go, name: go , size: small}
+    - { image: ccc, name: ccc, command: build.sh, args: main, repos: ["https://github.com/anthropics/claudes-c-compiler/tree/main"] , size: small}
+    - { image: misc, name: tinycc, command: build-tinycc.sh , size: small}
+    - { image: misc, name: cc65, command: buildcc65.sh, repos: ["https://github.com/cc65/cc65/tree/master"] , size: small}
+    - { image: misc, name: mrustc, command: build-mrustc.sh, args: master, repos: ["https://github.com/thepowersgang/mrustc/tree/master"] , size: small}
     - { image: rust-cg-gcc, name: rustc-cg-gcc_master, command: build.sh, args: master, repos: ["https://github.com/rust-lang/rustc_codegen_gcc/tree/master", "https://github.com/rust-lang/gcc/tree/master"] }
     - { image: misc, name: SPIRV-Tools, command: build-spirv-tools.sh, args: main, repos: ["https://github.com/KhronosGroup/SPIRV-Tools/tree/main"] }
-    - { image: lc3, name: lc3, command: build.sh, repos: ["https://github.com/xavierrouth/lc3-compiler"] }
-    - { image: c2rust, name: c2rust, command: build.sh, args: master, repos: ["https://github.com/immunant/c2rust/tree/master"] }
-    - { image: misc, name: clspv, command: build-clspv.sh, args: main, repos: ["https://github.com/google/clspv/tree/main"] }
-    - { image: jakt, name: jakt, command: build.sh, args: trunk, repos: ["https://github.com/SerenityOS/jakt/tree/main"] }
-    - { image: misc, name: cppfront, command: build-cppfront.sh, args: trunk, repos: ["https://github.com/hsutter/cppfront/tree/main"] }
-    - { image: misc, name: dxc, command: build-dxc.sh, args: trunk, repos: ["https://github.com/microsoft/DirectXShaderCompiler/tree/main"] }
-    - { image: misc, name: pahole, command: build-pahole.sh, args: trunk }
-    - { image: misc, name: movfuscator, command: build-movfuscator.sh, repos: ["https://github.com/xoreaxeaxeax/movfuscator/tree/master"] }
-    - { image: misc, name: wyrm, command: build-wyrm-transpiler.sh, repos: ["https://github.com/jeremy-rifkin/wyrm/tree/main"] }
-    - { image: ncc-ng, name: ncc-ng, command: build.sh, args: trunk, repos: ["https://github.com/Norcroft/ncc-ng/tree/trunk"] }
+    - { image: lc3, name: lc3, command: build.sh, repos: ["https://github.com/xavierrouth/lc3-compiler"] , size: small}
+    - { image: c2rust, name: c2rust, command: build.sh, args: master, repos: ["https://github.com/immunant/c2rust/tree/master"] , size: small}
+    - { image: misc, name: clspv, command: build-clspv.sh, args: main, repos: ["https://github.com/google/clspv/tree/main"] , size: small}
+    - { image: jakt, name: jakt, command: build.sh, args: trunk, repos: ["https://github.com/SerenityOS/jakt/tree/main"] , size: small}
+    - { image: misc, name: cppfront, command: build-cppfront.sh, args: trunk, repos: ["https://github.com/hsutter/cppfront/tree/main"] , size: small}
+    - { image: misc, name: dxc, command: build-dxc.sh, args: trunk, repos: ["https://github.com/microsoft/DirectXShaderCompiler/tree/main"] , size: small}
+    - { image: misc, name: pahole, command: build-pahole.sh, args: trunk , size: small}
+    - { image: misc, name: movfuscator, command: build-movfuscator.sh, repos: ["https://github.com/xoreaxeaxeax/movfuscator/tree/master"] , size: small}
+    - { image: misc, name: wyrm, command: build-wyrm-transpiler.sh, repos: ["https://github.com/jeremy-rifkin/wyrm/tree/main"] , size: small}
+    - { image: ncc-ng, name: ncc-ng, command: build.sh, args: trunk, repos: ["https://github.com/Norcroft/ncc-ng/tree/trunk"] , size: small}
     - { image: gcc-cross, name: arm32, args: "arm trunk" }
     - { image: gcc-cross, name: arm64, args: "arm64 trunk" }
     - { image: gcc-cross, name: riscv32, args: "riscv32 trunk" }
@@ -93,21 +93,21 @@ compilers:
     # - { image: clang, name: dang, args: dang-main }
 
     - { image: clang, name: widberg, args: widberg-main, repos: ["https://github.com/widberg/llvm-project-widberg-extensions/tree/main"] }
-    - { image: ispc, name: ispc, repos: ["https://github.com/ispc/ispc"] }
+    - { image: ispc, name: ispc, repos: ["https://github.com/ispc/ispc"] , size: small}
 
     # See https://github.com/compiler-explorer/compiler-explorer/issues/6828
     # - { image: ispc, name: ispc_templates_new, args: templates_new-trunk }
 
     # See https://github.com/compiler-explorer/d8-builder/issues/2
     # - { image: d8, name: d8 }
-    - { image: hylo, name: hylo, repos: ["https://github.com/hylo-lang/hylo/tree/main"] }
-    - { image: vast, name: vast, repos: ["https://github.com/trailofbits/vast/tree/master"] }
-    - { image: mads, name: madpascal, args: trunk, repos: ["https://github.com/tebe6502/Mad-Assembler/tree/master", "https://github.com/tebe6502/Mad-Pascal/tree/master"] }
+    - { image: hylo, name: hylo, repos: ["https://github.com/hylo-lang/hylo/tree/main"] , size: small}
+    - { image: vast, name: vast, repos: ["https://github.com/trailofbits/vast/tree/master"] , size: small}
+    - { image: mads, name: madpascal, args: trunk, repos: ["https://github.com/tebe6502/Mad-Assembler/tree/master", "https://github.com/tebe6502/Mad-Pascal/tree/master"] , size: small}
     - { image: clang, name: circt_trunk, command: build-circt.sh, args: trunk, repos: ["https://github.com/llvm/circt/tree/main"] }
-    - { image: clad, name: clad, args: trunk, repos: ["https://github.com/vgvassilev/clad/tree/master"] }
-    - { image: clad, name: clad-trunk-clang-21.1.0, args: trunk-clang-21.1.0, repos: ["https://github.com/vgvassilev/clad/tree/master"] }
-    - { image: miri, name: miri, command: build.sh, args: nightly }
-    - { image: micropython, name: micropython, command: build.sh, args: preview, repos: ["https://github.com/micropython/micropython"] }
+    - { image: clad, name: clad, args: trunk, repos: ["https://github.com/vgvassilev/clad/tree/master"] , size: small}
+    - { image: clad, name: clad-trunk-clang-21.1.0, args: trunk-clang-21.1.0, repos: ["https://github.com/vgvassilev/clad/tree/master"] , size: small}
+    - { image: miri, name: miri, command: build.sh, args: nightly , size: medium}
+    - { image: micropython, name: micropython, command: build.sh, args: preview, repos: ["https://github.com/micropython/micropython"] , size: small}
 
   ad_hoc:
     - { image: gcc, command: build.sh }

--- a/make_builds.py
+++ b/make_builds.py
@@ -12,10 +12,18 @@ import urllib.parse
 # Number of days without commits to consider a repo stale
 STALE_DAYS = 7
 
+SIZE_TO_LABELS = {
+    "large": "[ 'self-hosted', 'ce', 'linux', 'x64' ]",
+    "medium": "[ 'self-hosted', 'ce', 'linux', 'x64', 'medium' ]",
+    "small": "[ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]",
+}
+
 
 def make_yaml_doc(
-    friendly_name: str, image: str, name: str, command: str, args: str, repos: list[str]
+    friendly_name: str, image: str, name: str, command: str, args: str, repos: list[str],
+    size: str = "large",
 ) -> str:
+    runs_on = SIZE_TO_LABELS[size]
     # If repos are specified, add a check-activity job that runs first on a cheap runner
     if repos:
         repos_json = json.dumps(repos)
@@ -72,7 +80,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{{{ needs.check-activity.outputs.should_build == 'true' }}}}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: {runs_on}
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0
@@ -99,7 +107,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: {runs_on}
     steps:
       - name: Start from a clean directory
         uses: AutoModality/action-clean@v1.1.0
@@ -153,6 +161,7 @@ def main(yaml_file: TextIO, status_file: TextIO, output_dir: str):
         command = daily_compiler.get("command", "build.sh")
         args = daily_compiler.get("args", "trunk")
         repos = daily_compiler.get("repos", [])
+        size = daily_compiler.get("size", "large")
         build_yml = f"build-daily-{name}.yml"
         friendly_name = f"{name} via {image} {args}"
         (output_path / build_yml).write_text(
@@ -163,6 +172,7 @@ def main(yaml_file: TextIO, status_file: TextIO, output_dir: str):
                 command=command,
                 args=args,
                 repos=repos,
+                size=size,
             )
         )
         badges[friendly_name] = make_status_badges(friendly_name, name, build_yml)


### PR DESCRIPTION
## Summary
- Adds `size` field support to `make_builds.py` — maps `small`/`medium`/`large` to appropriate `runs-on` labels
- Tags compiler entries in `compilers.yaml` with appropriate runner tier
- Regenerates all workflow YAMLs
- Rebased onto #58 (repos URLs PR) — merged `repos` and `size` fields correctly

## Runner tier assignments

**Medium (16 vCPU):** dotnet, miri

**Small (8 vCPU):** go, ccc, tinycc, cc65, mrustc, lc3, c2rust, clspv, jakt, cppfront, dxc, pahole, movfuscator, wyrm, ncc-ng, ispc, hylo, vast, madpascal, clad (both entries), micropython

**Large (32-64 vCPU, unchanged):** all gcc/clang/llvm builds, gcc-cross, mlir_trunk, circt_trunk, rustc-cg-gcc, SPIRV-Tools, widberg, llvm_spirv

## Notes
- Depends on compiler-explorer/ce-ci#18 to provision the small/medium runner fleets
- Untagged entries default to `large` (no behavior change for existing heavy builds)

## Test plan
- [x] `make_builds.py` runs cleanly, pre-commit hooks pass
- [x] Spot-checked: `build-daily-go.yml` → small, `build-daily-dotnet.yml` → medium, `build-daily-gcc.yml` → large
- [ ] After ce-ci runners are deployed, verify small/medium jobs pick up runners correctly

🤖 Generated by LLM (Claude, via OpenClaw)