### PR TITLE
⬆️ Bump GitHub Actions, drop unmaintained action-clean

### DIFF
--- a/.github/actions/daily-build/action.yml
+++ b/.github/actions/daily-build/action.yml
@@ -24,7 +24,8 @@ runs:
   using: "composite"
   steps:
     - name: Start from a clean directory
-      uses: AutoModality/action-clean@v1.1.0
+      shell: bash
+      run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
     - uses: actions/checkout@v6
     - name: Get previous build version number, and start the run
       shell: bash

--- a/.github/actions/daily-build/action.yml
+++ b/.github/actions/daily-build/action.yml
@@ -24,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Start from a clean directory
-      uses: AutoModality/action-clean@v1.1.1
+      uses: AutoModality/action-clean@v1.1.0
     - uses: actions/checkout@v6
     - name: Get previous build version number, and start the run
       shell: bash

--- a/.github/actions/daily-build/action.yml
+++ b/.github/actions/daily-build/action.yml
@@ -24,8 +24,8 @@ runs:
   using: "composite"
   steps:
     - name: Start from a clean directory
-      uses: AutoModality/action-clean@v1.1.0
-    - uses: actions/checkout@v4
+      uses: AutoModality/action-clean@v1.1.1
+    - uses: actions/checkout@v6
     - name: Get previous build version number, and start the run
       shell: bash
       id: previous

--- a/.github/workflows/build-daily-SPIRV-Tools.yml
+++ b/.github/workflows/build-daily-SPIRV-Tools.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-SPIRV-Tools.yml
+++ b/.github/workflows/build-daily-SPIRV-Tools.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-SPIRV-Tools.yml
+++ b/.github/workflows/build-daily-SPIRV-Tools.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-arm32.yml
+++ b/.github/workflows/build-daily-arm32.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-arm32.yml
+++ b/.github/workflows/build-daily-arm32.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-arm32.yml
+++ b/.github/workflows/build-daily-arm32.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-arm64.yml
+++ b/.github/workflows/build-daily-arm64.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-arm64.yml
+++ b/.github/workflows/build-daily-arm64.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-arm64.yml
+++ b/.github/workflows/build-daily-arm64.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-bpf.yml
+++ b/.github/workflows/build-daily-bpf.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-bpf.yml
+++ b/.github/workflows/build-daily-bpf.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-bpf.yml
+++ b/.github/workflows/build-daily-bpf.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-c2rust.yml
+++ b/.github/workflows/build-daily-c2rust.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-c2rust.yml
+++ b/.github/workflows/build-daily-c2rust.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-c2rust.yml
+++ b/.github/workflows/build-daily-c2rust.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-cc65.yml
+++ b/.github/workflows/build-daily-cc65.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-cc65.yml
+++ b/.github/workflows/build-daily-cc65.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-cc65.yml
+++ b/.github/workflows/build-daily-cc65.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-ccc.yml
+++ b/.github/workflows/build-daily-ccc.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-ccc.yml
+++ b/.github/workflows/build-daily-ccc.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-ccc.yml
+++ b/.github/workflows/build-daily-ccc.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-circt_trunk.yml
+++ b/.github/workflows/build-daily-circt_trunk.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-circt_trunk.yml
+++ b/.github/workflows/build-daily-circt_trunk.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-circt_trunk.yml
+++ b/.github/workflows/build-daily-circt_trunk.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clad-trunk-clang-21.1.0.yml
+++ b/.github/workflows/build-daily-clad-trunk-clang-21.1.0.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clad-trunk-clang-21.1.0.yml
+++ b/.github/workflows/build-daily-clad-trunk-clang-21.1.0.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clad-trunk-clang-21.1.0.yml
+++ b/.github/workflows/build-daily-clad-trunk-clang-21.1.0.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clad.yml
+++ b/.github/workflows/build-daily-clad.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clad.yml
+++ b/.github/workflows/build-daily-clad.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clad.yml
+++ b/.github/workflows/build-daily-clad.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang.thephd.dev.yml
+++ b/.github/workflows/build-daily-clang.thephd.dev.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang.thephd.dev.yml
+++ b/.github/workflows/build-daily-clang.thephd.dev.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang.thephd.dev.yml
+++ b/.github/workflows/build-daily-clang.thephd.dev.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang.yml
+++ b/.github/workflows/build-daily-clang.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang.yml
+++ b/.github/workflows/build-daily-clang.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang.yml
+++ b/.github/workflows/build-daily-clang.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_amdgpu.yml
+++ b/.github/workflows/build-daily-clang_amdgpu.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_amdgpu.yml
+++ b/.github/workflows/build-daily-clang_amdgpu.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_amdgpu.yml
+++ b/.github/workflows/build-daily-clang_amdgpu.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_assertions.yml
+++ b/.github/workflows/build-daily-clang_assertions.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_assertions.yml
+++ b/.github/workflows/build-daily-clang_assertions.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_assertions.yml
+++ b/.github/workflows/build-daily-clang_assertions.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_autonsdmi.yml
+++ b/.github/workflows/build-daily-clang_autonsdmi.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_autonsdmi.yml
+++ b/.github/workflows/build-daily-clang_autonsdmi.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_autonsdmi.yml
+++ b/.github/workflows/build-daily-clang_autonsdmi.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_barry.yml
+++ b/.github/workflows/build-daily-clang_barry.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_barry.yml
+++ b/.github/workflows/build-daily-clang_barry.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_barry.yml
+++ b/.github/workflows/build-daily-clang_barry.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_bb_p2996.yml
+++ b/.github/workflows/build-daily-clang_bb_p2996.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_bb_p2996.yml
+++ b/.github/workflows/build-daily-clang_bb_p2996.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_bb_p2996.yml
+++ b/.github/workflows/build-daily-clang_bb_p2996.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_chrisbazley.yml
+++ b/.github/workflows/build-daily-clang_chrisbazley.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_chrisbazley.yml
+++ b/.github/workflows/build-daily-clang_chrisbazley.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_chrisbazley.yml
+++ b/.github/workflows/build-daily-clang_chrisbazley.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_cppx.yml
+++ b/.github/workflows/build-daily-clang_cppx.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_cppx.yml
+++ b/.github/workflows/build-daily-clang_cppx.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_cppx.yml
+++ b/.github/workflows/build-daily-clang_cppx.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_cppx_ext.yml
+++ b/.github/workflows/build-daily-clang_cppx_ext.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_cppx_ext.yml
+++ b/.github/workflows/build-daily-clang_cppx_ext.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_cppx_ext.yml
+++ b/.github/workflows/build-daily-clang_cppx_ext.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_cppx_p2320.yml
+++ b/.github/workflows/build-daily-clang_cppx_p2320.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_cppx_p2320.yml
+++ b/.github/workflows/build-daily-clang_cppx_p2320.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_cppx_p2320.yml
+++ b/.github/workflows/build-daily-clang_cppx_p2320.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_ericwf_contracts.yml
+++ b/.github/workflows/build-daily-clang_ericwf_contracts.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_ericwf_contracts.yml
+++ b/.github/workflows/build-daily-clang_ericwf_contracts.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_ericwf_contracts.yml
+++ b/.github/workflows/build-daily-clang_ericwf_contracts.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_hana.yml
+++ b/.github/workflows/build-daily-clang_hana.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_hana.yml
+++ b/.github/workflows/build-daily-clang_hana.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_hana.yml
+++ b/.github/workflows/build-daily-clang_hana.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_implicit_constexpr.yml
+++ b/.github/workflows/build-daily-clang_implicit_constexpr.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_implicit_constexpr.yml
+++ b/.github/workflows/build-daily-clang_implicit_constexpr.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_implicit_constexpr.yml
+++ b/.github/workflows/build-daily-clang_implicit_constexpr.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_ir.yml
+++ b/.github/workflows/build-daily-clang_ir.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_ir.yml
+++ b/.github/workflows/build-daily-clang_ir.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_ir.yml
+++ b/.github/workflows/build-daily-clang_ir.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_lifetime.yml
+++ b/.github/workflows/build-daily-clang_lifetime.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_lifetime.yml
+++ b/.github/workflows/build-daily-clang_lifetime.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_lifetime.yml
+++ b/.github/workflows/build-daily-clang_lifetime.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_llvmflang.yml
+++ b/.github/workflows/build-daily-clang_llvmflang.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_llvmflang.yml
+++ b/.github/workflows/build-daily-clang_llvmflang.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_llvmflang.yml
+++ b/.github/workflows/build-daily-clang_llvmflang.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_mizvekov_resugar.yml
+++ b/.github/workflows/build-daily-clang_mizvekov_resugar.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_mizvekov_resugar.yml
+++ b/.github/workflows/build-daily-clang_mizvekov_resugar.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_mizvekov_resugar.yml
+++ b/.github/workflows/build-daily-clang_mizvekov_resugar.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p1061.yml
+++ b/.github/workflows/build-daily-clang_p1061.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p1061.yml
+++ b/.github/workflows/build-daily-clang_p1061.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p1061.yml
+++ b/.github/workflows/build-daily-clang_p1061.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p1974.yml
+++ b/.github/workflows/build-daily-clang_p1974.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p1974.yml
+++ b/.github/workflows/build-daily-clang_p1974.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p1974.yml
+++ b/.github/workflows/build-daily-clang_p1974.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p2561.yml
+++ b/.github/workflows/build-daily-clang_p2561.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p2561.yml
+++ b/.github/workflows/build-daily-clang_p2561.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p2561.yml
+++ b/.github/workflows/build-daily-clang_p2561.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p2998.yml
+++ b/.github/workflows/build-daily-clang_p2998.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p2998.yml
+++ b/.github/workflows/build-daily-clang_p2998.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p2998.yml
+++ b/.github/workflows/build-daily-clang_p2998.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3039.yml
+++ b/.github/workflows/build-daily-clang_p3039.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3039.yml
+++ b/.github/workflows/build-daily-clang_p3039.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3039.yml
+++ b/.github/workflows/build-daily-clang_p3039.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3068.yml
+++ b/.github/workflows/build-daily-clang_p3068.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3068.yml
+++ b/.github/workflows/build-daily-clang_p3068.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3068.yml
+++ b/.github/workflows/build-daily-clang_p3068.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3309.yml
+++ b/.github/workflows/build-daily-clang_p3309.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3309.yml
+++ b/.github/workflows/build-daily-clang_p3309.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3309.yml
+++ b/.github/workflows/build-daily-clang_p3309.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3334.yml
+++ b/.github/workflows/build-daily-clang_p3334.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3334.yml
+++ b/.github/workflows/build-daily-clang_p3334.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3334.yml
+++ b/.github/workflows/build-daily-clang_p3334.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3367.yml
+++ b/.github/workflows/build-daily-clang_p3367.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3367.yml
+++ b/.github/workflows/build-daily-clang_p3367.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3367.yml
+++ b/.github/workflows/build-daily-clang_p3367.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3372.yml
+++ b/.github/workflows/build-daily-clang_p3372.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3372.yml
+++ b/.github/workflows/build-daily-clang_p3372.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3372.yml
+++ b/.github/workflows/build-daily-clang_p3372.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3385.yml
+++ b/.github/workflows/build-daily-clang_p3385.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3385.yml
+++ b/.github/workflows/build-daily-clang_p3385.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3385.yml
+++ b/.github/workflows/build-daily-clang_p3385.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3412.yml
+++ b/.github/workflows/build-daily-clang_p3412.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3412.yml
+++ b/.github/workflows/build-daily-clang_p3412.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3412.yml
+++ b/.github/workflows/build-daily-clang_p3412.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3776.yml
+++ b/.github/workflows/build-daily-clang_p3776.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3776.yml
+++ b/.github/workflows/build-daily-clang_p3776.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3776.yml
+++ b/.github/workflows/build-daily-clang_p3776.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3822.yml
+++ b/.github/workflows/build-daily-clang_p3822.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3822.yml
+++ b/.github/workflows/build-daily-clang_p3822.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3822.yml
+++ b/.github/workflows/build-daily-clang_p3822.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3951.yml
+++ b/.github/workflows/build-daily-clang_p3951.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3951.yml
+++ b/.github/workflows/build-daily-clang_p3951.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_p3951.yml
+++ b/.github/workflows/build-daily-clang_p3951.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_parmexpr.yml
+++ b/.github/workflows/build-daily-clang_parmexpr.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_parmexpr.yml
+++ b/.github/workflows/build-daily-clang_parmexpr.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_parmexpr.yml
+++ b/.github/workflows/build-daily-clang_parmexpr.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_patmat.yml
+++ b/.github/workflows/build-daily-clang_patmat.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_patmat.yml
+++ b/.github/workflows/build-daily-clang_patmat.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_patmat.yml
+++ b/.github/workflows/build-daily-clang_patmat.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_reflection.yml
+++ b/.github/workflows/build-daily-clang_reflection.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_reflection.yml
+++ b/.github/workflows/build-daily-clang_reflection.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_reflection.yml
+++ b/.github/workflows/build-daily-clang_reflection.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_relocatable.yml
+++ b/.github/workflows/build-daily-clang_relocatable.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_relocatable.yml
+++ b/.github/workflows/build-daily-clang_relocatable.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_relocatable.yml
+++ b/.github/workflows/build-daily-clang_relocatable.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_swiftlang.yml
+++ b/.github/workflows/build-daily-clang_swiftlang.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_swiftlang.yml
+++ b/.github/workflows/build-daily-clang_swiftlang.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_swiftlang.yml
+++ b/.github/workflows/build-daily-clang_swiftlang.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_variadic_friends.yml
+++ b/.github/workflows/build-daily-clang_variadic_friends.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_variadic_friends.yml
+++ b/.github/workflows/build-daily-clang_variadic_friends.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_variadic_friends.yml
+++ b/.github/workflows/build-daily-clang_variadic_friends.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clspv.yml
+++ b/.github/workflows/build-daily-clspv.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clspv.yml
+++ b/.github/workflows/build-daily-clspv.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clspv.yml
+++ b/.github/workflows/build-daily-clspv.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-cppfront.yml
+++ b/.github/workflows/build-daily-cppfront.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-cppfront.yml
+++ b/.github/workflows/build-daily-cppfront.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-cppfront.yml
+++ b/.github/workflows/build-daily-cppfront.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-dotnet.yml
+++ b/.github/workflows/build-daily-dotnet.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'medium' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-dotnet.yml
+++ b/.github/workflows/build-daily-dotnet.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'medium' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-dotnet.yml
+++ b/.github/workflows/build-daily-dotnet.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'medium' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-dxc.yml
+++ b/.github/workflows/build-daily-dxc.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-dxc.yml
+++ b/.github/workflows/build-daily-dxc.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-dxc.yml
+++ b/.github/workflows/build-daily-dxc.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc.thephd.dev.yml
+++ b/.github/workflows/build-daily-gcc.thephd.dev.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc.thephd.dev.yml
+++ b/.github/workflows/build-daily-gcc.thephd.dev.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc.thephd.dev.yml
+++ b/.github/workflows/build-daily-gcc.thephd.dev.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc.yml
+++ b/.github/workflows/build-daily-gcc.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc.yml
+++ b/.github/workflows/build-daily-gcc.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc.yml
+++ b/.github/workflows/build-daily-gcc.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_cobol_master.yml
+++ b/.github/workflows/build-daily-gcc_cobol_master.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_cobol_master.yml
+++ b/.github/workflows/build-daily-gcc_cobol_master.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_cobol_master.yml
+++ b/.github/workflows/build-daily-gcc_cobol_master.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_contracts.yml
+++ b/.github/workflows/build-daily-gcc_contracts.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_contracts.yml
+++ b/.github/workflows/build-daily-gcc_contracts.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_contracts.yml
+++ b/.github/workflows/build-daily-gcc_contracts.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_contracts_base.yml
+++ b/.github/workflows/build-daily-gcc_contracts_base.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_contracts_base.yml
+++ b/.github/workflows/build-daily-gcc_contracts_base.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_contracts_base.yml
+++ b/.github/workflows/build-daily-gcc_contracts_base.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_contracts_gnu.yml
+++ b/.github/workflows/build-daily-gcc_contracts_gnu.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_contracts_gnu.yml
+++ b/.github/workflows/build-daily-gcc_contracts_gnu.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_contracts_gnu.yml
+++ b/.github/workflows/build-daily-gcc_contracts_gnu.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_contracts_labels.yml
+++ b/.github/workflows/build-daily-gcc_contracts_labels.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_contracts_labels.yml
+++ b/.github/workflows/build-daily-gcc_contracts_labels.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_contracts_labels.yml
+++ b/.github/workflows/build-daily-gcc_contracts_labels.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_contracts_nonattr.yml
+++ b/.github/workflows/build-daily-gcc_contracts_nonattr.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_contracts_nonattr.yml
+++ b/.github/workflows/build-daily-gcc_contracts_nonattr.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_contracts_nonattr.yml
+++ b/.github/workflows/build-daily-gcc_contracts_nonattr.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_coroutines.yml
+++ b/.github/workflows/build-daily-gcc_coroutines.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_coroutines.yml
+++ b/.github/workflows/build-daily-gcc_coroutines.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_coroutines.yml
+++ b/.github/workflows/build-daily-gcc_coroutines.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_gccrs_master.yml
+++ b/.github/workflows/build-daily-gcc_gccrs_master.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_gccrs_master.yml
+++ b/.github/workflows/build-daily-gcc_gccrs_master.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_gccrs_master.yml
+++ b/.github/workflows/build-daily-gcc_gccrs_master.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_lambda_p2034.yml
+++ b/.github/workflows/build-daily-gcc_lambda_p2034.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_lambda_p2034.yml
+++ b/.github/workflows/build-daily-gcc_lambda_p2034.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_lambda_p2034.yml
+++ b/.github/workflows/build-daily-gcc_lambda_p2034.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_modules.yml
+++ b/.github/workflows/build-daily-gcc_modules.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_modules.yml
+++ b/.github/workflows/build-daily-gcc_modules.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_modules.yml
+++ b/.github/workflows/build-daily-gcc_modules.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_p1144.yml
+++ b/.github/workflows/build-daily-gcc_p1144.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_p1144.yml
+++ b/.github/workflows/build-daily-gcc_p1144.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_p1144.yml
+++ b/.github/workflows/build-daily-gcc_p1144.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_thomas_healy.yml
+++ b/.github/workflows/build-daily-gcc_thomas_healy.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_thomas_healy.yml
+++ b/.github/workflows/build-daily-gcc_thomas_healy.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_thomas_healy.yml
+++ b/.github/workflows/build-daily-gcc_thomas_healy.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_trivial_relocation.yml
+++ b/.github/workflows/build-daily-gcc_trivial_relocation.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_trivial_relocation.yml
+++ b/.github/workflows/build-daily-gcc_trivial_relocation.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-gcc_trivial_relocation.yml
+++ b/.github/workflows/build-daily-gcc_trivial_relocation.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-go.yml
+++ b/.github/workflows/build-daily-go.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-go.yml
+++ b/.github/workflows/build-daily-go.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-go.yml
+++ b/.github/workflows/build-daily-go.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-hylo.yml
+++ b/.github/workflows/build-daily-hylo.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-hylo.yml
+++ b/.github/workflows/build-daily-hylo.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-hylo.yml
+++ b/.github/workflows/build-daily-hylo.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-ispc.yml
+++ b/.github/workflows/build-daily-ispc.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-ispc.yml
+++ b/.github/workflows/build-daily-ispc.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-ispc.yml
+++ b/.github/workflows/build-daily-ispc.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-jakt.yml
+++ b/.github/workflows/build-daily-jakt.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-jakt.yml
+++ b/.github/workflows/build-daily-jakt.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-jakt.yml
+++ b/.github/workflows/build-daily-jakt.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-lc3.yml
+++ b/.github/workflows/build-daily-lc3.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-lc3.yml
+++ b/.github/workflows/build-daily-lc3.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-lc3.yml
+++ b/.github/workflows/build-daily-lc3.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-llvm.yml
+++ b/.github/workflows/build-daily-llvm.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-llvm.yml
+++ b/.github/workflows/build-daily-llvm.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-llvm.yml
+++ b/.github/workflows/build-daily-llvm.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-llvm_spirv.yml
+++ b/.github/workflows/build-daily-llvm_spirv.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-llvm_spirv.yml
+++ b/.github/workflows/build-daily-llvm_spirv.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-llvm_spirv.yml
+++ b/.github/workflows/build-daily-llvm_spirv.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-madpascal.yml
+++ b/.github/workflows/build-daily-madpascal.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-madpascal.yml
+++ b/.github/workflows/build-daily-madpascal.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-madpascal.yml
+++ b/.github/workflows/build-daily-madpascal.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-micropython.yml
+++ b/.github/workflows/build-daily-micropython.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-micropython.yml
+++ b/.github/workflows/build-daily-micropython.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-micropython.yml
+++ b/.github/workflows/build-daily-micropython.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-miri.yml
+++ b/.github/workflows/build-daily-miri.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'medium' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-miri.yml
+++ b/.github/workflows/build-daily-miri.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'medium' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-miri.yml
+++ b/.github/workflows/build-daily-miri.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'medium' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-mlir_trunk.yml
+++ b/.github/workflows/build-daily-mlir_trunk.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-mlir_trunk.yml
+++ b/.github/workflows/build-daily-mlir_trunk.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-mlir_trunk.yml
+++ b/.github/workflows/build-daily-mlir_trunk.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-movfuscator.yml
+++ b/.github/workflows/build-daily-movfuscator.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-movfuscator.yml
+++ b/.github/workflows/build-daily-movfuscator.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-movfuscator.yml
+++ b/.github/workflows/build-daily-movfuscator.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-mrustc.yml
+++ b/.github/workflows/build-daily-mrustc.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-mrustc.yml
+++ b/.github/workflows/build-daily-mrustc.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-mrustc.yml
+++ b/.github/workflows/build-daily-mrustc.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-ncc-ng.yml
+++ b/.github/workflows/build-daily-ncc-ng.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-ncc-ng.yml
+++ b/.github/workflows/build-daily-ncc-ng.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-ncc-ng.yml
+++ b/.github/workflows/build-daily-ncc-ng.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-pahole.yml
+++ b/.github/workflows/build-daily-pahole.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-pahole.yml
+++ b/.github/workflows/build-daily-pahole.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-pahole.yml
+++ b/.github/workflows/build-daily-pahole.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-powerpc64.yml
+++ b/.github/workflows/build-daily-powerpc64.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-powerpc64.yml
+++ b/.github/workflows/build-daily-powerpc64.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-powerpc64.yml
+++ b/.github/workflows/build-daily-powerpc64.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-powerpc64le.yml
+++ b/.github/workflows/build-daily-powerpc64le.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-powerpc64le.yml
+++ b/.github/workflows/build-daily-powerpc64le.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-powerpc64le.yml
+++ b/.github/workflows/build-daily-powerpc64le.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-riscv32.yml
+++ b/.github/workflows/build-daily-riscv32.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-riscv32.yml
+++ b/.github/workflows/build-daily-riscv32.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-riscv32.yml
+++ b/.github/workflows/build-daily-riscv32.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-riscv64.yml
+++ b/.github/workflows/build-daily-riscv64.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-riscv64.yml
+++ b/.github/workflows/build-daily-riscv64.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-riscv64.yml
+++ b/.github/workflows/build-daily-riscv64.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-rustc-cg-gcc_master.yml
+++ b/.github/workflows/build-daily-rustc-cg-gcc_master.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-rustc-cg-gcc_master.yml
+++ b/.github/workflows/build-daily-rustc-cg-gcc_master.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-rustc-cg-gcc_master.yml
+++ b/.github/workflows/build-daily-rustc-cg-gcc_master.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-tinycc.yml
+++ b/.github/workflows/build-daily-tinycc.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-tinycc.yml
+++ b/.github/workflows/build-daily-tinycc.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-tinycc.yml
+++ b/.github/workflows/build-daily-tinycc.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-vast.yml
+++ b/.github/workflows/build-daily-vast.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-vast.yml
+++ b/.github/workflows/build-daily-vast.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-vast.yml
+++ b/.github/workflows/build-daily-vast.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-widberg.yml
+++ b/.github/workflows/build-daily-widberg.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-widberg.yml
+++ b/.github/workflows/build-daily-widberg.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-widberg.yml
+++ b/.github/workflows/build-daily-widberg.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-wyrm.yml
+++ b/.github/workflows/build-daily-wyrm.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-wyrm.yml
+++ b/.github/workflows/build-daily-wyrm.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-wyrm.yml
+++ b/.github/workflows/build-daily-wyrm.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
       - name: pre-commit hooks

--- a/.github/workflows/install-compilers.yml
+++ b/.github/workflows/install-compilers.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ['self-hosted', 'ce', 'linux', 'x64', 'small']
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        uses: AutoModality/action-clean@v1.1.1
 
       - name: Checkout infra repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: compiler-explorer/infra
           path: infra

--- a/.github/workflows/install-compilers.yml
+++ b/.github/workflows/install-compilers.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ['self-hosted', 'ce', 'linux', 'x64', 'small']
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
 
       - name: Checkout infra repo
         uses: actions/checkout@v6

--- a/.github/workflows/install-compilers.yml
+++ b/.github/workflows/install-compilers.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ['self-hosted', 'ce', 'linux', 'x64', 'small']
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
 
       - name: Checkout infra repo
         uses: actions/checkout@v6

--- a/make_builds.py
+++ b/make_builds.py
@@ -83,7 +83,7 @@ jobs:
     runs-on: {runs_on}
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
@@ -110,7 +110,7 @@ jobs:
     runs-on: {runs_on}
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
+        run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/make_builds.py
+++ b/make_builds.py
@@ -83,7 +83,7 @@ jobs:
     runs-on: {runs_on}
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
@@ -110,7 +110,7 @@ jobs:
     runs-on: {runs_on}
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.1
+        uses: AutoModality/action-clean@v1.1.0
       - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build

--- a/make_builds.py
+++ b/make_builds.py
@@ -83,8 +83,8 @@ jobs:
     runs-on: {runs_on}
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:
@@ -110,8 +110,8 @@ jobs:
     runs-on: {runs_on}
     steps:
       - name: Start from a clean directory
-        uses: AutoModality/action-clean@v1.1.0
-      - uses: actions/checkout@v4
+        uses: AutoModality/action-clean@v1.1.1
+      - uses: actions/checkout@v6
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:


### PR DESCRIPTION
## Summary
- ✅ `actions/checkout` v4 → v6 (floating major)
- ✅ `astral-sh/setup-uv` v4 → v8.1.0 (exact pin — v8 stopped publishing major/minor float tags)
- 🗑 Dropped `AutoModality/action-clean` entirely. Replaced with the same inline pattern `infra/` uses:
  ```yaml
  - name: Start from a clean directory
    run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
  ```
  `sudo` is required because the Docker builds produce root-owned output.
- `prewk/s3-cp-action` already at major v2, left alone.

The autogenerated `build-daily-*.yml` files were regenerated from the updated template in `make_builds.py`.

## Why drop action-clean?
- `v1.1.1` shipped a literal `rm -rf ..` regression in `entrypoint.sh` (caught by the smoke test below — see run [25385673996](https://github.com/compiler-explorer/compiler-workflows/actions/runs/25385673996)). `rm`'s built-in safeguard against `..` is the only thing that stopped it from clobbering the runner's bind-mounted `_temp` state.
- The repo's last release is years old; it's effectively unmaintained.
- The `@v1` floating tag is stale (still points at v1.0.0), so floating-major doesn't help us.
- The action does three lines of shell. No reason to depend on a dead repo for that.

## Compatibility note
`actions/checkout@v6` requires self-hosted runner ≥ 2.329.0. The `ce-ci` packer config pins `runner_version = "2.330.0"`, so all runners launched from current AMIs clear the bar.

## Test plan
- [x] `make test` passes locally
- [x] CI green on this branch (exercises `setup-uv@v8.1.0` and `checkout@v6` on GitHub-hosted runners)
- [x] `gh workflow run build-daily-tinycc.yml --ref bump-actions-versions` smoke test passed on a real self-hosted runner with the inline cleanup ([run 25386307728](https://github.com/compiler-explorer/compiler-workflows/actions/runs/25386307728), 1m31s, all steps green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)