### PR TITLE
One-click build-and-deploy for trusted compiler authors

### DIFF
--- a/.github/actions/daily-build/action.yml
+++ b/.github/actions/daily-build/action.yml
@@ -20,6 +20,11 @@ inputs:
     description: "Secret key"
     required: true
 
+outputs:
+  status:
+    description: "Build status: OK, SKIPPED (source unchanged), or empty if the build failed"
+    value: ${{ steps.build.outputs.status }}
+
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/build-daily-clang_barry.yml
+++ b/.github/workflows/build-daily-clang_barry.yml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+    inputs:
+      install:
+        description: 'Install to Compiler Explorer after a successful build'
+        type: boolean
+        default: true
 
 jobs:
   check-activity:
@@ -65,11 +70,14 @@ jobs:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    outputs:
+      status: ${{ steps.build.outputs.status }}
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
+        id: build
         uses: ./.github/actions/daily-build
         with:
           image: clang
@@ -78,3 +86,12 @@ jobs:
           args: barry-clang-trunk
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  install:
+    needs: daily-build
+    # Only manual dispatches install from here, and only after a fresh, successful
+    # build; scheduled builds are installed by the admin node's nightly install.
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.install && needs.daily-build.outputs.status == 'OK' }}
+    uses: ./.github/workflows/install-compilers.yml
+    with:
+      compilers: "clang barry-clang-trunk"

--- a/.github/workflows/build-daily-clang_barry.yml
+++ b/.github/workflows/build-daily-clang_barry.yml
@@ -89,9 +89,9 @@ jobs:
 
   install:
     needs: daily-build
-    # Only manual dispatches install from here, and only after a fresh, successful
-    # build; scheduled builds are installed by the admin node's nightly install.
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.install && needs.daily-build.outputs.status == 'OK' }}
     uses: ./.github/workflows/install-compilers.yml
     with:
       compilers: "clang barry-clang-trunk"
+      enable_nightly: true
+      force: true

--- a/.github/workflows/build-daily-clang_hana.yml
+++ b/.github/workflows/build-daily-clang_hana.yml
@@ -89,9 +89,9 @@ jobs:
 
   install:
     needs: daily-build
-    # Only manual dispatches install from here, and only after a fresh, successful
-    # build; scheduled builds are installed by the admin node's nightly install.
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.install && needs.daily-build.outputs.status == 'OK' }}
     uses: ./.github/workflows/install-compilers.yml
     with:
       compilers: "clang hana-clang-trunk"
+      enable_nightly: true
+      force: true

--- a/.github/workflows/build-daily-clang_hana.yml
+++ b/.github/workflows/build-daily-clang_hana.yml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+    inputs:
+      install:
+        description: 'Install to Compiler Explorer after a successful build'
+        type: boolean
+        default: true
 
 jobs:
   check-activity:
@@ -65,11 +70,14 @@ jobs:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    outputs:
+      status: ${{ steps.build.outputs.status }}
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
       - name: Run the build
+        id: build
         uses: ./.github/actions/daily-build
         with:
           image: clang
@@ -78,3 +86,12 @@ jobs:
           args: hana-clang-trunk
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  install:
+    needs: daily-build
+    # Only manual dispatches install from here, and only after a fresh, successful
+    # build; scheduled builds are installed by the admin node's nightly install.
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.install && needs.daily-build.outputs.status == 'OK' }}
+    uses: ./.github/workflows/install-compilers.yml
+    with:
+      compilers: "clang hana-clang-trunk"

--- a/.github/workflows/install-compilers.yml
+++ b/.github/workflows/install-compilers.yml
@@ -1,23 +1,24 @@
 name: Install compiler(s)
 run-name: Install ${{ inputs.compilers }}
 
+# Installs nightly compilers onto Compiler Explorer, exactly as the admin's manual
+# `ce_install --enable nightly install --force ...` would. Callable from the generated
+# build-daily workflows (see the `install` field in compilers.yaml), or dispatched by
+# hand for ad-hoc installs.
+
 on:
+  workflow_call:
+    inputs:
+      compilers:
+        description: 'ce_install pattern to install (e.g. "clang hana-clang-trunk")'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       compilers:
-        description: 'Compiler pattern to install (e.g., "clang hana-clang-trunk")'
+        description: 'ce_install pattern to install (e.g. "clang hana-clang-trunk")'
         required: true
         type: string
-      enable_nightly:
-        description: 'Enable nightly builds'
-        required: false
-        type: boolean
-        default: true
-      force:
-        description: 'Force install even if would otherwise skip'
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   install:
@@ -30,21 +31,16 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: compiler-explorer/infra
-          path: infra
 
       - name: Set up environment
-        working-directory: infra
         run: make ce
 
-      - name: Install compilers
-        working-directory: infra
+      - name: Install ${{ inputs.compilers }}
+        env:
+          # Via the environment (not template interpolation) so the pattern can't
+          # smuggle shell syntax into the run script.
+          COMPILERS: ${{ inputs.compilers }}
+        # set -f: the pattern is ce_install filter words — word-split it, never glob it.
         run: |
-          ENABLE_FLAG=""
-          if [[ "${{ inputs.enable_nightly }}" == "true" ]]; then
-            ENABLE_FLAG="--enable nightly"
-          fi
-          FORCE_FLAG=""
-          if [[ "${{ inputs.force }}" == "true" ]]; then
-            FORCE_FLAG="--force"
-          fi
-          sudo bin/ce_install --check-user nobody $ENABLE_FLAG install $FORCE_FLAG ${{ inputs.compilers }}
+          set -f
+          sudo bin/ce_install --check-user nobody --enable nightly install --force $COMPILERS

--- a/.github/workflows/install-compilers.yml
+++ b/.github/workflows/install-compilers.yml
@@ -1,24 +1,39 @@
 name: Install compiler(s)
 run-name: Install ${{ inputs.compilers }}
 
-# Installs nightly compilers onto Compiler Explorer, exactly as the admin's manual
-# `ce_install --enable nightly install --force ...` would. Callable from the generated
-# build-daily workflows (see the `install` field in compilers.yaml), or dispatched by
-# hand for ad-hoc installs.
-
 on:
   workflow_call:
     inputs:
       compilers:
-        description: 'ce_install pattern to install (e.g. "clang hana-clang-trunk")'
+        description: 'Compiler pattern to install (e.g., "clang hana-clang-trunk")'
         required: true
         type: string
+      enable_nightly:
+        description: 'Enable nightly builds'
+        required: false
+        type: boolean
+        default: false
+      force:
+        description: 'Force install even if would otherwise skip'
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       compilers:
-        description: 'ce_install pattern to install (e.g. "clang hana-clang-trunk")'
+        description: 'Compiler pattern to install (e.g., "clang hana-clang-trunk")'
         required: true
         type: string
+      enable_nightly:
+        description: 'Enable nightly builds'
+        required: false
+        type: boolean
+        default: false
+      force:
+        description: 'Force install even if would otherwise skip'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   install:
@@ -37,10 +52,18 @@ jobs:
 
       - name: Install ${{ inputs.compilers }}
         env:
-          # Via the environment (not template interpolation) so the pattern can't
-          # smuggle shell syntax into the run script.
+          # via env rather than interpolation so input can't inject shell syntax
           COMPILERS: ${{ inputs.compilers }}
-        # set -f: the pattern is ce_install filter words — word-split it, never glob it.
+          ENABLE_NIGHTLY: ${{ inputs.enable_nightly }}
+          FORCE: ${{ inputs.force }}
         run: |
-          set -f
-          sudo bin/ce_install --check-user nobody --enable nightly install --force $COMPILERS
+          set -f # word-split $COMPILERS, but never glob it
+          ENABLE_FLAG=""
+          if [[ "$ENABLE_NIGHTLY" == "true" ]]; then
+            ENABLE_FLAG="--enable nightly"
+          fi
+          FORCE_FLAG=""
+          if [[ "$FORCE" == "true" ]]; then
+            FORCE_FLAG="--force"
+          fi
+          sudo bin/ce_install --check-user nobody $ENABLE_FLAG install $FORCE_FLAG $COMPILERS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,7 @@ make install-pre-commit # Install pre-commit hooks
    - { image: <docker-image>, name: <unique-name>, args: <args>, repos: ["https://github.com/owner/repo"] }
    # with specific branch:
    - { image: <docker-image>, name: <unique-name>, args: <args>, repos: ["https://github.com/owner/repo/tree/branch-name"] }
-   # with one-click deploy: manual dispatches get an "install" tickbox (default on) that
-   # installs the result onto Compiler Explorer once a fresh build succeeds. Scheduled
-   # builds never install this way (the admin node's nightly install handles those):
+   # with one-click deploy (manual dispatches get an "install after build" tickbox, default on):
    - { image: <docker-image>, name: <unique-name>, args: <args>, install: <ce_install pattern, e.g. clang hana-clang-trunk> }
    ```
 2. Run `make build-yamls` (or let pre-commit do it)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ make install-pre-commit # Install pre-commit hooks
 
 - `.github/actions/daily-build/action.yml` - Reusable composite action for all builds
 - `.github/workflows/build-daily-*.yml` - Auto-generated (DO NOT EDIT directly)
+- `.github/workflows/install-compilers.yml` - Reusable workflow installing compilers via `ce_install`; called by install-enabled build workflows, or dispatched by hand
 - `.github/workflows/ci.yml` - CI for this repo itself
 
 ### Adding a New Compiler
@@ -43,6 +44,10 @@ make install-pre-commit # Install pre-commit hooks
    - { image: <docker-image>, name: <unique-name>, args: <args>, repos: ["https://github.com/owner/repo"] }
    # with specific branch:
    - { image: <docker-image>, name: <unique-name>, args: <args>, repos: ["https://github.com/owner/repo/tree/branch-name"] }
+   # with one-click deploy: manual dispatches get an "install" tickbox (default on) that
+   # installs the result onto Compiler Explorer once a fresh build succeeds. Scheduled
+   # builds never install this way (the admin node's nightly install handles those):
+   - { image: <docker-image>, name: <unique-name>, args: <args>, install: <ce_install pattern, e.g. clang hana-clang-trunk> }
    ```
 2. Run `make build-yamls` (or let pre-commit do it)
 3. Also add entry in `remove_old_compilers.sh` in the infra repository

--- a/README.md
+++ b/README.md
@@ -37,23 +37,31 @@ Contact Matt directly by email, or on Discord to be added to the group.
    "Show more workflows..." a few times
 3. Choose your build (you can bookmark this page for ease of return later)
 4. Choose "Run workflow" at the top right of the pane with prior builds
-5. Choose the green "Run workflow"
-6. After a pause of a few seconds your build should appear at the top of the list
-7. It may take a few minutes to get scheduled, but you should then be able to
+5. If your build supports it, you'll see an "Install to Compiler Explorer after
+   a successful build" tickbox, on by default: leave it ticked and your compiler
+   will be installed on the live site as soon as the build succeeds — no further
+   steps needed. (No tickbox? Ask an admin to add an `install:` entry for your
+   compiler in `compilers.yaml`, or install by hand as below.)
+6. Choose the green "Run workflow"
+7. After a pause of a few seconds your build should appear at the top of the list
+8. It may take a few minutes to get scheduled, but you should then be able to
    watch it build. If it _builds quickly_ then check the output: we try not to
    build if we think there has been no changes. Check you pushed your compiler's
    changes if not, else contact the admins on Discord
-8. Ensure everything goes green
-9. Trigger an installation
+9. Ensure everything goes green. If you left the tickbox on, that includes the
+   "install" job, and your compiler is then live: you're done. (A build we
+   skipped as unchanged won't install.)
 
-### Triggering an installation
+### Triggering an installation by hand
+
+Builds with the install tickbox deploy themselves; this is for the rest, or
+for re-installing without waiting for a build.
 
 1. Head to https://github.com/compiler-explorer/compiler-workflows/actions/workflows/install-compilers.yml
 2. Click "Run workflow"
 3. Type in the build type and name, e.g. `clang hana-clang-trunk`
-4. If today's build has already deployed and you want to force, tick "Force install"
-5. Click "Run workflow"
-6. Check it completes OK _and_ that the end of the output of the "install" / "install compilers" step looks something like:
+4. Click "Run workflow"
+5. Check it completes OK _and_ that the end of the output of the "install" / "install compilers" step looks something like:
 
 ```
 2026-01-03 20:20:32,446 compilers/c++/nightly/clang hana-clang-trunk WARNING  Not running on admin node - not saving compiler version info to AWS
@@ -73,8 +81,7 @@ You can script these, if you download and setup the `gh` Github tool. Then you c
 ```
 gh workflow run -R compiler-explorer/compiler-workflows \
     'Install compiler(s)' \
-    -f compilers='clang hana-clang-trunk' \
-    -f force=true
+    -f compilers='clang hana-clang-trunk'
 ```
 
 Where you can change the `compilers=` line appropriately.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,11 @@ for re-installing without waiting for a build.
 1. Head to https://github.com/compiler-explorer/compiler-workflows/actions/workflows/install-compilers.yml
 2. Click "Run workflow"
 3. Type in the build type and name, e.g. `clang hana-clang-trunk`
-4. Click "Run workflow"
-5. Check it completes OK _and_ that the end of the output of the "install" / "install compilers" step looks something like:
+4. For a nightly compiler (like that example), tick "Enable nightly builds" —
+   beware that this changes what a broad pattern like `gcc` matches
+5. If it's already installed and you want to reinstall, tick "Force install"
+6. Click "Run workflow"
+7. Check it completes OK _and_ that the end of the output of the "install" / "install compilers" step looks something like:
 
 ```
 2026-01-03 20:20:32,446 compilers/c++/nightly/clang hana-clang-trunk WARNING  Not running on admin node - not saving compiler version info to AWS
@@ -81,7 +84,9 @@ You can script these, if you download and setup the `gh` Github tool. Then you c
 ```
 gh workflow run -R compiler-explorer/compiler-workflows \
     'Install compiler(s)' \
-    -f compilers='clang hana-clang-trunk'
+    -f compilers='clang hana-clang-trunk' \
+    -f enable_nightly=true \
+    -f force=true
 ```
 
 Where you can change the `compilers=` line appropriately.

--- a/compilers.yaml
+++ b/compilers.yaml
@@ -46,7 +46,7 @@ compilers:
     - { image: clang, name: clang_p3039, args: p3039-trunk, repos: ["https://github.com/Imagix/llvm-project-p3039/tree/p3039experimental"] }
     - { image: clang, name: clang_p3309, args: p3309-trunk, repos: ["https://github.com/hanickadot/llvm-project/tree/P3309-constexpr-atomic-and-atomic-ref"] }
     - { image: clang, name: clang_p3367, args: p3367-trunk, repos: ["https://github.com/hanickadot/llvm-project/tree/P3367-constexpr-coroutines"] }
-    - { image: clang, name: clang_hana, args: hana-clang-trunk, repos: ["https://github.com/hanickadot/llvm-project/tree/compiler-explorer/hana-clang"] }
+    - { image: clang, name: clang_hana, args: hana-clang-trunk, install: clang hana-clang-trunk, repos: ["https://github.com/hanickadot/llvm-project/tree/compiler-explorer/hana-clang"] }
     - { image: clang, name: clang_p3334, args: p3334-trunk, repos: ["https://github.com/tal-yac/llvm-project/tree/p3334-cross-static"] }
     - { image: clang, name: clang_p3372, args: p3372-trunk, repos: ["https://github.com/hanickadot/llvm-project/tree/P3372-constexpr-containers-and-adaptors"] }
     - { image: clang, name: clang_p3385, args: p3385-trunk, repos: ["https://github.com/zebullax/clang-p2996/tree/3385R5"] }
@@ -54,13 +54,12 @@ compilers:
     - { image: clang, name: clang_p3776, args: p3776-trunk, repos: ["https://github.com/term-est/llvm-project/tree/P3776-More-Trailing-Commas"] }
     - { image: clang, name: clang_p3822, args: p3822-trunk, repos: ["https://github.com/yuxuanchen1997/llvm-project/tree/users/yuxuanchen1997/p3822r0-requirements-noexcept"] }
     - { image: clang, name: clang_p3951, args: p3951-trunk, repos: ["https://github.com/brevzin/llvm-project/tree/template-strings"] }
-    - { image: clang, name: clang_barry, args: barry-clang-trunk, repos: ["https://github.com/brevzin/llvm-project/tree/compiler-explorer/barry"] }
+    - { image: clang, name: clang_barry, args: barry-clang-trunk, install: clang barry-clang-trunk, repos: ["https://github.com/brevzin/llvm-project/tree/compiler-explorer/barry"] }
     - { image: clang, name: clang_parmexpr, command: build-parmexpr.sh, repos: ["https://github.com/ricejasonf/parametric_expressions/tree/master"] }
     - { image: clang, name: clang_patmat, args: patmat-trunk, repos: ["https://github.com/mpark/llvm-project/tree/p2688-pattern-matching"] }
     - { image: clang, name: clang_reflection, args: reflection-trunk, repos: ["https://github.com/matus-chochlik/llvm-project/tree/reflection"] }
     - { image: clang, name: clang_relocatable, args: relocatable-trunk, repos: ["https://github.com/Quuxplusone/llvm-project/tree/trivially-relocatable"] }
     - { image: clang, name: clang_variadic_friends, args: variadic-friends-trunk, repos: ["https://github.com/dancrn/llvm-project/tree/cxx-variadic-friends"] }
-    - { image: clang, name: clang_hana, args: hana-clang-trunk, repos: ["https://github.com/hanickadot/llvm-project/tree/compiler-explorer/hana-clang"] }
     - { image: clang, name: clang_swiftlang, args: swiftlang-trunk, repos: ["https://github.com/swiftlang/llvm-project/tree/next"] }
     - { image: dotnet, name: dotnet, command: build.sh, args: trunk, repos: ["https://github.com/dotnet/runtime"] , size: medium}
     - { image: clang, name: mlir_trunk, args: mlir-trunk }

--- a/make_builds.py
+++ b/make_builds.py
@@ -21,9 +21,39 @@ SIZE_TO_LABELS = {
 
 def make_yaml_doc(
     friendly_name: str, image: str, name: str, command: str, args: str, repos: list[str],
-    size: str = "large",
+    size: str = "large", install: str | None = None,
 ) -> str:
     runs_on = SIZE_TO_LABELS[size]
+    # Compilers with an `install` target (a ce_install pattern) get an on-by-default
+    # dispatch input and a follow-up job that installs the result, so compiler authors
+    # can build-and-deploy in one click. Scheduled runs never install from here: the
+    # nightly install on the admin node picks those up.
+    workflow_dispatch_block = "workflow_dispatch:"
+    build_outputs = ""
+    build_id = ""
+    install_job = ""
+    if install:
+        workflow_dispatch_block = """workflow_dispatch:
+    inputs:
+      install:
+        description: 'Install to Compiler Explorer after a successful build'
+        type: boolean
+        default: true"""
+        build_outputs = """
+    outputs:
+      status: ${{ steps.build.outputs.status }}"""
+        build_id = """
+        id: build"""
+        install_job = f"""
+  install:
+    needs: daily-build
+    # Only manual dispatches install from here, and only after a fresh, successful
+    # build; scheduled builds are installed by the admin node's nightly install.
+    if: ${{{{ github.event_name == 'workflow_dispatch' && inputs.install && needs.daily-build.outputs.status == 'OK' }}}}
+    uses: ./.github/workflows/install-compilers.yml
+    with:
+      compilers: {json.dumps(install)}
+"""
     # If repos are specified, add a check-activity job that runs first on a cheap runner
     if repos:
         repos_json = json.dumps(repos)
@@ -33,7 +63,7 @@ name: {friendly_name}
 on:
   schedule:
     - cron: '0 0 * * *'
-  workflow_dispatch:
+  {workflow_dispatch_block}
 
 jobs:
   check-activity:
@@ -93,12 +123,12 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{{{ needs.check-activity.outputs.should_build == 'true' }}}}
-    runs-on: {runs_on}
+    runs-on: {runs_on}{build_outputs}
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
-      - name: Run the build
+      - name: Run the build{build_id}
         uses: ./.github/actions/daily-build
         with:
           image: {image}
@@ -107,7 +137,7 @@ jobs:
           args: {args}
           AWS_ACCESS_KEY_ID: ${{{{ secrets.AWS_ACCESS_KEY_ID }}}}
           AWS_SECRET_ACCESS_KEY: ${{{{ secrets.AWS_SECRET_ACCESS_KEY }}}}
-"""
+{install_job}"""
     else:
         # No repos specified - simple workflow without activity check
         return f"""### DO NOT EDIT - created by a script ###
@@ -116,16 +146,16 @@ name: {friendly_name}
 on:
   schedule:
     - cron: '0 0 * * *'
-  workflow_dispatch:
+  {workflow_dispatch_block}
 
 jobs:
   daily-build:
-    runs-on: {runs_on}
+    runs-on: {runs_on}{build_outputs}
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v6
-      - name: Run the build
+      - name: Run the build{build_id}
         uses: ./.github/actions/daily-build
         with:
           image: {image}
@@ -134,7 +164,7 @@ jobs:
           args: {args}
           AWS_ACCESS_KEY_ID: ${{{{ secrets.AWS_ACCESS_KEY_ID }}}}
           AWS_SECRET_ACCESS_KEY: ${{{{ secrets.AWS_SECRET_ACCESS_KEY }}}}
-"""
+{install_job}"""
 
 
 def make_shield_url(friendly_name: str, build_name: str, colour:str, query: str) -> str:
@@ -175,6 +205,7 @@ def main(yaml_file: TextIO, status_file: TextIO, output_dir: str):
         args = daily_compiler.get("args", "trunk")
         repos = daily_compiler.get("repos", [])
         size = daily_compiler.get("size", "large")
+        install = daily_compiler.get("install")
         build_yml = f"build-daily-{name}.yml"
         friendly_name = f"{name} via {image} {args}"
         (output_path / build_yml).write_text(
@@ -186,6 +217,7 @@ def main(yaml_file: TextIO, status_file: TextIO, output_dir: str):
                 args=args,
                 repos=repos,
                 size=size,
+                install=install,
             )
         )
         badges[friendly_name] = make_status_badges(friendly_name, name, build_yml)

--- a/make_builds.py
+++ b/make_builds.py
@@ -24,10 +24,8 @@ def make_yaml_doc(
     size: str = "large", install: str | None = None,
 ) -> str:
     runs_on = SIZE_TO_LABELS[size]
-    # Compilers with an `install` target (a ce_install pattern) get an on-by-default
-    # dispatch input and a follow-up job that installs the result, so compiler authors
-    # can build-and-deploy in one click. Scheduled runs never install from here: the
-    # nightly install on the admin node picks those up.
+    # If an install target is specified, manual dispatches get an on-by-default
+    # "install after build" input; scheduled builds are installed by the admin node
     workflow_dispatch_block = "workflow_dispatch:"
     build_outputs = ""
     build_id = ""
@@ -47,12 +45,12 @@ def make_yaml_doc(
         install_job = f"""
   install:
     needs: daily-build
-    # Only manual dispatches install from here, and only after a fresh, successful
-    # build; scheduled builds are installed by the admin node's nightly install.
     if: ${{{{ github.event_name == 'workflow_dispatch' && inputs.install && needs.daily-build.outputs.status == 'OK' }}}}
     uses: ./.github/workflows/install-compilers.yml
     with:
       compilers: {json.dumps(install)}
+      enable_nightly: true
+      force: true
 """
     # If repos are specified, add a check-activity job that runs first on a cheap runner
     if repos:


### PR DESCRIPTION
Lets trusted compiler authors (Hana, Barry) build **and deploy** their compilers with a single "Run workflow" click, instead of build → wait → ask an admin to `ce_install` by hand.

## How it works

- `compilers.yaml` entries can opt in with `install: <ce_install pattern>` (added for `clang_hana` and `clang_barry`; it's one field to extend to others).
- Their generated workflows gain an **"Install to Compiler Explorer after a successful build"** dispatch input, on by default, and an `install` job that calls the shared install workflow with the baked-in pattern — nothing for the author to type or get wrong.
- The install only runs for **manual dispatches** (scheduled builds keep flowing through the admin node's nightly install), and only when the build reports a fresh `OK`: the `daily-build` composite action now declares its `status` output, so `SKIPPED` (source unchanged) or failed builds never (re-)install. A stale-repo dispatch skips the build, and with it the install.
- `install-compilers.yml` becomes a **reusable workflow** (`workflow_call`) invoked by the generated jobs, keeping its manual dispatch with the `enable_nightly`/`force` options intact — both now **defaulting off**, since a bare pattern like `gcc` means something very different with nightly enabled. The build-triggered install passes `enable_nightly: true, force: true` explicitly (reinstalling a freshly built nightly is exactly the forced case). The pattern reaches the script via env vars with globbing disabled, so the input can't smuggle shell syntax.

## Also

- Removed an accidental duplicate `clang_hana` entry (the generator wrote the same file twice).
- README rewritten for the new author flow; CLAUDE.md documents the field.

Behaviour note: the only manual-dispatch change is `enable_nightly` defaulting off (previously on) — installing a nightly by hand now needs the tickbox. An audit (org-wide code search + all local checkouts) found no script dispatching this workflow; the only reference was the README `gh` example, updated here.

## Validation

Only the two opted-in generated workflows changed — all other `build-daily-*.yml` regenerate byte-identically. Pre-commit suite passes (yaml check, regeneration up-to-date, tests). An independent review verified the event/skip semantics against documented GitHub Actions behaviour: `inputs` is empty on `schedule`, the implicit `success()` check skips `install` when `daily-build` fails or is skipped, and job-level `uses: ./…` runs the called workflow at the caller's commit. Suggested end-to-end test: `gh workflow run build-daily-clang_hana.yml` and watch the build → install chain deploy `hana-clang-trunk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

