### PR TITLE
Add actionlint to pre-commit

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+self-hosted-runner:
+  # Labels of our self-hosted CE runners (see the ce-ci repository)
+  labels:
+    - ce
+    - small
+    - medium

--- a/.github/workflows/install-compilers.yml
+++ b/.github/workflows/install-compilers.yml
@@ -66,4 +66,5 @@ jobs:
           if [[ "$FORCE" == "true" ]]; then
             FORCE_FLAG="--force"
           fi
+          # shellcheck disable=SC2086 # word-splitting the flag and filter word lists is the point
           sudo bin/ce_install --check-user nobody $ENABLE_FLAG install $FORCE_FLAG $COMPILERS

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,10 @@ repos:
       rev: 2.1.5
       hooks:
         - id: shellcheck
+    - repo: https://github.com/rhysd/actionlint
+      rev: v1.7.12
+      hooks:
+        - id: actionlint
     - repo: local
       hooks:
         - id: builds-up-to-date


### PR DESCRIPTION
First of a set of PRs adding [actionlint](https://github.com/rhysd/actionlint) across the CE repos — this repo first since workflows are the product here, and a generator bug fans out into ~95 files.

It statically checks every workflow: schema/typos, expression type-checking against real contexts (an `if:` referencing a job output or dispatch input that doesn't exist is an error, not a silent runtime false), reusable-workflow `with:` vs declared inputs, and shellcheck over `run:` scripts. It would have machine-verified the trickiest parts of #67.

- Hook added to pre-commit (pre-commit auto-provisions the Go toolchain; CI already runs `make pre-commit`, so it's enforced there too).
- `.github/actionlint.yaml` declares the self-hosted runner labels (`ce`, `small`, `medium`) so `runs-on` checking works.
- Sole finding in the whole repo: SC2086 on the `ce_install` argument list in `install-compilers.yml`, where word-splitting is deliberate — annotated with a disable-and-reason rather than quoted (which would break it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)