### PR TITLE
Bump checkout to v7 and setup-uv to v8.3.2

### DIFF
--- a/.github/actions/daily-build/action.yml
+++ b/.github/actions/daily-build/action.yml
@@ -31,7 +31,7 @@ runs:
     - name: Start from a clean directory
       shell: bash
       run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Get previous build version number, and start the run
       shell: bash
       id: previous

--- a/.github/workflows/build-daily-SPIRV-Tools.yml
+++ b/.github/workflows/build-daily-SPIRV-Tools.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-arm32.yml
+++ b/.github/workflows/build-daily-arm32.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-arm64.yml
+++ b/.github/workflows/build-daily-arm64.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-bpf.yml
+++ b/.github/workflows/build-daily-bpf.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-c2rust.yml
+++ b/.github/workflows/build-daily-c2rust.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-cc65.yml
+++ b/.github/workflows/build-daily-cc65.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-ccc.yml
+++ b/.github/workflows/build-daily-ccc.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-circt_trunk.yml
+++ b/.github/workflows/build-daily-circt_trunk.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clad-trunk-clang-21.1.0.yml
+++ b/.github/workflows/build-daily-clad-trunk-clang-21.1.0.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clad.yml
+++ b/.github/workflows/build-daily-clad.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang.thephd.dev.yml
+++ b/.github/workflows/build-daily-clang.thephd.dev.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang.yml
+++ b/.github/workflows/build-daily-clang.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_amdgpu.yml
+++ b/.github/workflows/build-daily-clang_amdgpu.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_assertions.yml
+++ b/.github/workflows/build-daily-clang_assertions.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_autonsdmi.yml
+++ b/.github/workflows/build-daily-clang_autonsdmi.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_barry.yml
+++ b/.github/workflows/build-daily-clang_barry.yml
@@ -75,7 +75,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         id: build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_bb_p2996.yml
+++ b/.github/workflows/build-daily-clang_bb_p2996.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_chrisbazley.yml
+++ b/.github/workflows/build-daily-clang_chrisbazley.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_cppx.yml
+++ b/.github/workflows/build-daily-clang_cppx.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_cppx_ext.yml
+++ b/.github/workflows/build-daily-clang_cppx_ext.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_cppx_p2320.yml
+++ b/.github/workflows/build-daily-clang_cppx_p2320.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_ericwf_contracts.yml
+++ b/.github/workflows/build-daily-clang_ericwf_contracts.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_hana.yml
+++ b/.github/workflows/build-daily-clang_hana.yml
@@ -75,7 +75,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         id: build
         uses: ./.github/actions/daily-build

--- a/.github/workflows/build-daily-clang_implicit_constexpr.yml
+++ b/.github/workflows/build-daily-clang_implicit_constexpr.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_ir.yml
+++ b/.github/workflows/build-daily-clang_ir.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_lifetime.yml
+++ b/.github/workflows/build-daily-clang_lifetime.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_llvmflang.yml
+++ b/.github/workflows/build-daily-clang_llvmflang.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_mizvekov_resugar.yml
+++ b/.github/workflows/build-daily-clang_mizvekov_resugar.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_notadragon_contracts_p3850.yml
+++ b/.github/workflows/build-daily-clang_notadragon_contracts_p3850.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p1061.yml
+++ b/.github/workflows/build-daily-clang_p1061.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p1974.yml
+++ b/.github/workflows/build-daily-clang_p1974.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p2561.yml
+++ b/.github/workflows/build-daily-clang_p2561.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p2998.yml
+++ b/.github/workflows/build-daily-clang_p2998.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3039.yml
+++ b/.github/workflows/build-daily-clang_p3039.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3068.yml
+++ b/.github/workflows/build-daily-clang_p3068.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3309.yml
+++ b/.github/workflows/build-daily-clang_p3309.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3334.yml
+++ b/.github/workflows/build-daily-clang_p3334.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3367.yml
+++ b/.github/workflows/build-daily-clang_p3367.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3372.yml
+++ b/.github/workflows/build-daily-clang_p3372.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3385.yml
+++ b/.github/workflows/build-daily-clang_p3385.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3412.yml
+++ b/.github/workflows/build-daily-clang_p3412.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3776.yml
+++ b/.github/workflows/build-daily-clang_p3776.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3817.yml
+++ b/.github/workflows/build-daily-clang_p3817.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3822.yml
+++ b/.github/workflows/build-daily-clang_p3822.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_p3951.yml
+++ b/.github/workflows/build-daily-clang_p3951.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_parmexpr.yml
+++ b/.github/workflows/build-daily-clang_parmexpr.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_patmat.yml
+++ b/.github/workflows/build-daily-clang_patmat.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_reflection.yml
+++ b/.github/workflows/build-daily-clang_reflection.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_relocatable.yml
+++ b/.github/workflows/build-daily-clang_relocatable.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_swiftlang.yml
+++ b/.github/workflows/build-daily-clang_swiftlang.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clang_variadic_friends.yml
+++ b/.github/workflows/build-daily-clang_variadic_friends.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-clspv.yml
+++ b/.github/workflows/build-daily-clspv.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-cppfront.yml
+++ b/.github/workflows/build-daily-cppfront.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-dotnet.yml
+++ b/.github/workflows/build-daily-dotnet.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-dxc.yml
+++ b/.github/workflows/build-daily-dxc.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc.thephd.dev.yml
+++ b/.github/workflows/build-daily-gcc.thephd.dev.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc.yml
+++ b/.github/workflows/build-daily-gcc.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_cobol_master.yml
+++ b/.github/workflows/build-daily-gcc_cobol_master.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_contracts.yml
+++ b/.github/workflows/build-daily-gcc_contracts.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_contracts_base.yml
+++ b/.github/workflows/build-daily-gcc_contracts_base.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_contracts_gnu.yml
+++ b/.github/workflows/build-daily-gcc_contracts_gnu.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_contracts_labels.yml
+++ b/.github/workflows/build-daily-gcc_contracts_labels.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_contracts_nonattr.yml
+++ b/.github/workflows/build-daily-gcc_contracts_nonattr.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_coroutines.yml
+++ b/.github/workflows/build-daily-gcc_coroutines.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_gccrs_master.yml
+++ b/.github/workflows/build-daily-gcc_gccrs_master.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_lambda_p2034.yml
+++ b/.github/workflows/build-daily-gcc_lambda_p2034.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_modules.yml
+++ b/.github/workflows/build-daily-gcc_modules.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_notadragon_contracts_p3850.yml
+++ b/.github/workflows/build-daily-gcc_notadragon_contracts_p3850.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_p1144.yml
+++ b/.github/workflows/build-daily-gcc_p1144.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_thomas_healy.yml
+++ b/.github/workflows/build-daily-gcc_thomas_healy.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-gcc_trivial_relocation.yml
+++ b/.github/workflows/build-daily-gcc_trivial_relocation.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-go.yml
+++ b/.github/workflows/build-daily-go.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-hylo.yml
+++ b/.github/workflows/build-daily-hylo.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-ispc.yml
+++ b/.github/workflows/build-daily-ispc.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-jakt.yml
+++ b/.github/workflows/build-daily-jakt.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-lc3.yml
+++ b/.github/workflows/build-daily-lc3.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-llvm.yml
+++ b/.github/workflows/build-daily-llvm.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-llvm_spirv.yml
+++ b/.github/workflows/build-daily-llvm_spirv.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-madpascal.yml
+++ b/.github/workflows/build-daily-madpascal.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-micropython.yml
+++ b/.github/workflows/build-daily-micropython.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-miri.yml
+++ b/.github/workflows/build-daily-miri.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-mlir_trunk.yml
+++ b/.github/workflows/build-daily-mlir_trunk.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-movfuscator.yml
+++ b/.github/workflows/build-daily-movfuscator.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-mrustc.yml
+++ b/.github/workflows/build-daily-mrustc.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-ncc-ng.yml
+++ b/.github/workflows/build-daily-ncc-ng.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-pahole.yml
+++ b/.github/workflows/build-daily-pahole.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-powerpc64.yml
+++ b/.github/workflows/build-daily-powerpc64.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-powerpc64le.yml
+++ b/.github/workflows/build-daily-powerpc64le.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-riscv32.yml
+++ b/.github/workflows/build-daily-riscv32.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-riscv64.yml
+++ b/.github/workflows/build-daily-riscv64.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-tinycc.yml
+++ b/.github/workflows/build-daily-tinycc.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-vast.yml
+++ b/.github/workflows/build-daily-vast.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-widberg.yml
+++ b/.github/workflows/build-daily-widberg.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/build-daily-wyrm.yml
+++ b/.github/workflows/build-daily-wyrm.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build
         uses: ./.github/actions/daily-build
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
       - name: pre-commit hooks

--- a/.github/workflows/install-compilers.yml
+++ b/.github/workflows/install-compilers.yml
@@ -43,7 +43,7 @@ jobs:
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
 
       - name: Checkout infra repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: compiler-explorer/infra
 

--- a/make_builds.py
+++ b/make_builds.py
@@ -125,7 +125,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build{build_id}
         uses: ./.github/actions/daily-build
         with:
@@ -152,7 +152,7 @@ jobs:
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Run the build{build_id}
         uses: ./.github/actions/daily-build
         with:


### PR DESCRIPTION
Companion to compiler-explorer#8936, bringing this repo to the same action majors.

This repo was already in good shape (checkout@v6 everywhere, which targets node24, and ci.yml already on uv rather than the old setup-python), so this is consistency rather than a deprecation fix:

- `actions/checkout` v6 → v7 in `make_builds.py`, the `daily-build` composite action, `ci.yml` and `install-compilers.yml`. v7's one behaviour change (blocking fork-PR checkout under `pull_request_target`/`workflow_run` unless opted in) is irrelevant here; nothing uses those triggers.
- `astral-sh/setup-uv` 8.1.0 → 8.3.2. It publishes immutable releases only (no floating major tags), so the exact pin needs occasional manual advancing.
- The 94 `build-daily-*.yml` changes are pure `make build-yamls` output; the regeneration produced exactly the one-line checkout bump per file, confirming generator and generated files were in sync.

`AutoModality/action-clean` and `prewk/s3-cp-action` are Docker actions, untouched by the Node runtime deprecations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)