### PR TITLE
Add auto-deploy for gcc_contracts_p4324 (Ville's P4324 contracts)

### DIFF
--- a/.github/workflows/build-daily-gcc_contracts_p4324.yml
+++ b/.github/workflows/build-daily-gcc_contracts_p4324.yml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+    inputs:
+      install:
+        description: 'Install to Compiler Explorer after a successful build'
+        type: boolean
+        default: true
 
 jobs:
   check-activity:
@@ -65,11 +70,14 @@ jobs:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
     runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    outputs:
+      status: ${{ steps.build.outputs.status }}
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete
       - uses: actions/checkout@v7
       - name: Run the build
+        id: build
         uses: ./.github/actions/daily-build
         with:
           image: gcc
@@ -78,3 +86,12 @@ jobs:
           args: contracts-p4324-trunk
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  install:
+    needs: daily-build
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.install && needs.daily-build.outputs.status == 'OK' }}
+    uses: ./.github/workflows/install-compilers.yml
+    with:
+      compilers: "gcc contracts-p4324-trunk"
+      enable_nightly: true
+      force: true

--- a/compilers.yaml
+++ b/compilers.yaml
@@ -13,7 +13,7 @@ compilers:
     - { image: gcc, name: gcc_contracts_base, args: contracts-base-trunk, repos: ["https://github.com/iains/gcc-git/tree/C++26-contracts-base"] }
     - { image: gcc, name: gcc_contracts_gnu, args: contracts-GNUext-trunk, repos: ["https://github.com/iains/gcc-git/tree/C++26-contracts-GNU-extensions"] }
     - { image: gcc, name: gcc_lambda_p2034, args: contracts-lambda-p2034-trunk, repos: ["https://github.com/villevoutilainen/gcc/tree/lambda-p2034"] }
-    - { image: gcc, name: gcc_contracts_p4324, args: contracts-p4324-trunk, repos: ["https://github.com/villevoutilainen/gcc/tree/p4324"] }
+    - { image: gcc, name: gcc_contracts_p4324, args: contracts-p4324-trunk, install: gcc contracts-p4324-trunk, repos: ["https://github.com/villevoutilainen/gcc/tree/p4324"] }
     - { image: gcc, name: gcc_coroutines, args: cxx-coroutines-trunk, repos: ["https://github.com/iains/gcc-cxx-coroutines/tree/c++-coroutines"] }
     - { image: gcc, name: gcc_trivial_relocation, args: trivial-relocation-trunk, repos: ["https://github.com/iains/gcc-git/tree/C++2z-trivial-relocation"] }
     - { image: gcc, name: gcc_gccrs_master, args: gccrs-master, repos: ["https://github.com/Rust-GCC/gccrs/tree/master"] }


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

Adds `install: gcc contracts-p4324-trunk` to the `gcc_contracts_p4324` entry in `compilers.yaml` and regenerates the workflow.

This gives Ville (and admins) the same one-click build-and-deploy capability that `clang_hana` and `clang_barry` already have: triggering the workflow manually will show an "Install to Compiler Explorer after a successful build" checkbox (on by default), and if the build succeeds with fresh artifacts it will automatically install `compilers/c++/nightly/gcc contracts-p4324-trunk` without needing a separate admin step.

Scheduled nightly builds are unaffected — those continue to install via the admin node's nightly install as before.