### PR TITLE
Ask for the `large` runner label explicitly

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,3 +4,4 @@ self-hosted-runner:
     - ce
     - small
     - medium
+    - large

--- a/.github/workflows/build-daily-SPIRV-Tools.yml
+++ b/.github/workflows/build-daily-SPIRV-Tools.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-arm32.yml
+++ b/.github/workflows/build-daily-arm32.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-arm64.yml
+++ b/.github/workflows/build-daily-arm64.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-bpf.yml
+++ b/.github/workflows/build-daily-bpf.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-circt_trunk.yml
+++ b/.github/workflows/build-daily-circt_trunk.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang.thephd.dev.yml
+++ b/.github/workflows/build-daily-clang.thephd.dev.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang.yml
+++ b/.github/workflows/build-daily-clang.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_amdgpu.yml
+++ b/.github/workflows/build-daily-clang_amdgpu.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_assertions.yml
+++ b/.github/workflows/build-daily-clang_assertions.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_autonsdmi.yml
+++ b/.github/workflows/build-daily-clang_autonsdmi.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_barry.yml
+++ b/.github/workflows/build-daily-clang_barry.yml
@@ -69,7 +69,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:

--- a/.github/workflows/build-daily-clang_bb_p2996.yml
+++ b/.github/workflows/build-daily-clang_bb_p2996.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_chrisbazley.yml
+++ b/.github/workflows/build-daily-clang_chrisbazley.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_cppx.yml
+++ b/.github/workflows/build-daily-clang_cppx.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_cppx_ext.yml
+++ b/.github/workflows/build-daily-clang_cppx_ext.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_cppx_p2320.yml
+++ b/.github/workflows/build-daily-clang_cppx_p2320.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_ericwf_contracts.yml
+++ b/.github/workflows/build-daily-clang_ericwf_contracts.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_hana.yml
+++ b/.github/workflows/build-daily-clang_hana.yml
@@ -69,7 +69,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:

--- a/.github/workflows/build-daily-clang_implicit_constexpr.yml
+++ b/.github/workflows/build-daily-clang_implicit_constexpr.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_ir.yml
+++ b/.github/workflows/build-daily-clang_ir.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_lifetime.yml
+++ b/.github/workflows/build-daily-clang_lifetime.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_llvmflang.yml
+++ b/.github/workflows/build-daily-clang_llvmflang.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_mizvekov_resugar.yml
+++ b/.github/workflows/build-daily-clang_mizvekov_resugar.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_notadragon_contracts_p3850.yml
+++ b/.github/workflows/build-daily-clang_notadragon_contracts_p3850.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_p1061.yml
+++ b/.github/workflows/build-daily-clang_p1061.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_p1974.yml
+++ b/.github/workflows/build-daily-clang_p1974.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_p2561.yml
+++ b/.github/workflows/build-daily-clang_p2561.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_p2998.yml
+++ b/.github/workflows/build-daily-clang_p2998.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_p3039.yml
+++ b/.github/workflows/build-daily-clang_p3039.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_p3068.yml
+++ b/.github/workflows/build-daily-clang_p3068.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_p3309.yml
+++ b/.github/workflows/build-daily-clang_p3309.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_p3334.yml
+++ b/.github/workflows/build-daily-clang_p3334.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_p3367.yml
+++ b/.github/workflows/build-daily-clang_p3367.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_p3372.yml
+++ b/.github/workflows/build-daily-clang_p3372.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_p3385.yml
+++ b/.github/workflows/build-daily-clang_p3385.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_p3412.yml
+++ b/.github/workflows/build-daily-clang_p3412.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_p3776.yml
+++ b/.github/workflows/build-daily-clang_p3776.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_p3817.yml
+++ b/.github/workflows/build-daily-clang_p3817.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_p3822.yml
+++ b/.github/workflows/build-daily-clang_p3822.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_p3951.yml
+++ b/.github/workflows/build-daily-clang_p3951.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_parmexpr.yml
+++ b/.github/workflows/build-daily-clang_parmexpr.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_patmat.yml
+++ b/.github/workflows/build-daily-clang_patmat.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_profiles_core_ub.yml
+++ b/.github/workflows/build-daily-clang_profiles_core_ub.yml
@@ -69,7 +69,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:

--- a/.github/workflows/build-daily-clang_profiles_init.yml
+++ b/.github/workflows/build-daily-clang_profiles_init.yml
@@ -69,7 +69,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:

--- a/.github/workflows/build-daily-clang_reflection.yml
+++ b/.github/workflows/build-daily-clang_reflection.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_relocatable.yml
+++ b/.github/workflows/build-daily-clang_relocatable.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_swiftlang.yml
+++ b/.github/workflows/build-daily-clang_swiftlang.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-clang_variadic_friends.yml
+++ b/.github/workflows/build-daily-clang_variadic_friends.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-gcc.thephd.dev.yml
+++ b/.github/workflows/build-daily-gcc.thephd.dev.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-gcc.yml
+++ b/.github/workflows/build-daily-gcc.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-gcc_cobol_master.yml
+++ b/.github/workflows/build-daily-gcc_cobol_master.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-gcc_contracts.yml
+++ b/.github/workflows/build-daily-gcc_contracts.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-gcc_contracts_base.yml
+++ b/.github/workflows/build-daily-gcc_contracts_base.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-gcc_contracts_gnu.yml
+++ b/.github/workflows/build-daily-gcc_contracts_gnu.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-gcc_contracts_labels.yml
+++ b/.github/workflows/build-daily-gcc_contracts_labels.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-gcc_contracts_nonattr.yml
+++ b/.github/workflows/build-daily-gcc_contracts_nonattr.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-gcc_contracts_p4324.yml
+++ b/.github/workflows/build-daily-gcc_contracts_p4324.yml
@@ -69,7 +69,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:

--- a/.github/workflows/build-daily-gcc_coroutines.yml
+++ b/.github/workflows/build-daily-gcc_coroutines.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-gcc_gccrs_master.yml
+++ b/.github/workflows/build-daily-gcc_gccrs_master.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-gcc_ilazaric_enclosing_cast.yml
+++ b/.github/workflows/build-daily-gcc_ilazaric_enclosing_cast.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-gcc_lambda_p2034.yml
+++ b/.github/workflows/build-daily-gcc_lambda_p2034.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-gcc_modules.yml
+++ b/.github/workflows/build-daily-gcc_modules.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-gcc_notadragon_contracts_p3850.yml
+++ b/.github/workflows/build-daily-gcc_notadragon_contracts_p3850.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-gcc_p1144.yml
+++ b/.github/workflows/build-daily-gcc_p1144.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-gcc_thomas_healy.yml
+++ b/.github/workflows/build-daily-gcc_thomas_healy.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-gcc_trivial_relocation.yml
+++ b/.github/workflows/build-daily-gcc_trivial_relocation.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-llvm.yml
+++ b/.github/workflows/build-daily-llvm.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-llvm_spirv.yml
+++ b/.github/workflows/build-daily-llvm_spirv.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-mlir_trunk.yml
+++ b/.github/workflows/build-daily-mlir_trunk.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-powerpc64.yml
+++ b/.github/workflows/build-daily-powerpc64.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-powerpc64le.yml
+++ b/.github/workflows/build-daily-powerpc64le.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-riscv32.yml
+++ b/.github/workflows/build-daily-riscv32.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-riscv64.yml
+++ b/.github/workflows/build-daily-riscv64.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   daily-build:
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-daily-widberg.yml
+++ b/.github/workflows/build-daily-widberg.yml
@@ -64,7 +64,7 @@ jobs:
   daily-build:
     needs: check-activity
     if: ${{ needs.check-activity.outputs.should_build == 'true' }}
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
     steps:
       - name: Start from a clean directory
         run: sudo find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/make_builds.py
+++ b/make_builds.py
@@ -13,7 +13,7 @@ import urllib.parse
 STALE_DAYS = 7
 
 SIZE_TO_LABELS = {
-    "large": "[ 'self-hosted', 'ce', 'linux', 'x64' ]",
+    "large": "[ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]",
     "medium": "[ 'self-hosted', 'ce', 'linux', 'x64', 'medium' ]",
     "small": "[ 'self-hosted', 'ce', 'linux', 'x64', 'small' ]",
 }


### PR DESCRIPTION
> ⚠️ **Draft on purpose. Do not merge until compiler-explorer/ce-ci#25 is applied**, or every daily build will request a label no runner carries and queue forever.

**Step 3 of the rollout in compiler-explorer/ce-ci#24.**

`SIZE_TO_LABELS["large"]` emits the bare `[self-hosted, ce, linux, x64]` set. GitHub reads that as "any runner carrying at least these labels", and the small and medium pools carry supersets of it, so they satisfy it too. `"large"` has therefore been the *absence* of a size constraint rather than a request for a large machine — and it is the default for every `compilers.yaml` entry without an explicit `size:`, so it applies to most of the fleet.

Measured, sampling `clang_llvmflang` job records 2026-04-30 to 2026-08-14: **31 of 107 ran on `ce-x64-small`, and not one of those 31 succeeded.** They were OOM-killed around 03:00 and nothing surfaced it.

### The change

One line in `make_builds.py` plus `make build-yamls`. The regenerated diff is 74 workflows, every changed line identical:

```diff
-    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64' ]
+    runs-on: [ 'self-hosted', 'ce', 'linux', 'x64', 'large' ]
```

I verified no `small` or `medium` workflow is touched, and that those two forms are the *only* differing lines in the whole generated diff.

`.github/actionlint.yaml` also gains `large`: it allowlists self-hosted labels, and the pre-commit hook rejected the change until it knew about the new one. Nice catch by the existing tooling.

Your "don't tag every build" default is preserved: `make_builds.py` still defaults `size="large"`, so nothing in `compilers.yaml` needs annotating. The default now just means something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
